### PR TITLE
updated trailing space for wallet name label

### DIFF
--- a/loopr-ios/Setting/SettingManageWallet/SettingManageWalletTableViewCell.xib
+++ b/loopr-ios/Setting/SettingManageWallet/SettingManageWalletTableViewCell.xib
@@ -1,11 +1,11 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="13771" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="14109" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
     <device id="retina4_7" orientation="portrait">
         <adaptation id="fullscreen"/>
     </device>
     <dependencies>
         <deployment identifier="iOS"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="13772"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="14088"/>
         <capability name="Safe area layout guides" minToolsVersion="9.0"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
@@ -20,9 +20,8 @@
                 <autoresizingMask key="autoresizingMask"/>
                 <subviews>
                     <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Label" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="XYG-qc-hhn">
-                        <rect key="frame" x="15" y="15" width="176" height="21"/>
+                        <rect key="frame" x="15" y="15" width="365" height="21"/>
                         <constraints>
-                            <constraint firstAttribute="width" constant="176" id="WJU-a3-qtc"/>
                             <constraint firstAttribute="height" constant="21" id="mFn-lg-s4F"/>
                         </constraints>
                         <fontDescription key="fontDescription" type="system" pointSize="17"/>
@@ -54,6 +53,7 @@
                     <constraint firstItem="Xmm-aW-i01" firstAttribute="top" secondItem="XYG-qc-hhn" secondAttribute="bottom" constant="12" id="Tbq-22-HwS"/>
                     <constraint firstAttribute="trailing" secondItem="yZC-kQ-ht9" secondAttribute="trailing" id="UmE-qh-L14"/>
                     <constraint firstItem="yZC-kQ-ht9" firstAttribute="leading" secondItem="H2p-sc-9uM" secondAttribute="leading" constant="15" id="YcG-CQ-ugh"/>
+                    <constraint firstAttribute="trailing" secondItem="XYG-qc-hhn" secondAttribute="trailing" constant="15" id="kbw-b3-yCs"/>
                     <constraint firstAttribute="trailing" secondItem="Xmm-aW-i01" secondAttribute="trailing" constant="12" id="txB-p0-8Fo"/>
                 </constraints>
             </tableViewCellContentView>


### PR DESCRIPTION
https://github.com/Loopring/loopr-ios/issues/56

I'll also update the wallet name length limit to 28 English characters. so it won't get truncated.